### PR TITLE
Add issues analyzer dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "cookie-parser": "~1.4.3",
+        "date-fns": "^2.16.1",
         "debug": "~2.6.9",
         "ejs": "^3.1.8",
         "esm": "^3.2.25",
@@ -22,6 +23,17 @@
         "eslint": "^8.20.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.26.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -435,6 +447,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -2009,6 +2036,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -2436,6 +2468,14 @@
     }
   },
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "requires": {
+        "regenerator-runtime": "^0.14.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2749,6 +2789,14 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
       }
     },
     "debug": {
@@ -3932,6 +3980,11 @@
           }
         }
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "cookie-parser": "~1.4.3",
+    "date-fns": "^2.16.1",
     "debug": "~2.6.9",
     "ejs": "^3.1.8",
     "esm": "^3.2.25",

--- a/parsers/gitlab-api/index.js
+++ b/parsers/gitlab-api/index.js
@@ -1,1 +1,2 @@
 export { parser as parseUser } from './user'
+export { parser as parseIssue } from './issue'

--- a/parsers/gitlab-api/issue.js
+++ b/parsers/gitlab-api/issue.js
@@ -1,0 +1,35 @@
+import { parseISO, isValid } from 'date-fns'
+
+import { parser as parseUser } from './user'
+
+const parseISODate = (dateStr) => {
+  const parsedDate = dateStr && parseISO(dateStr)
+
+  return isValid(parsedDate) ? parsedDate : null
+}
+
+const parser = ({
+  id,
+  project_id: projectId,
+  title,
+  description,
+  state, // Ex: "opened", "closed"
+  created_at: createdAt, // Ex: "2025-03-31T16:37:31.932-03:00"
+  updated_at: updatedAt, // Ex: "2025-03-31T16:37:31.932-03:00", null
+  closed_at: closedAt, // Ex: "2025-03-31T16:37:31.932-03:00", null
+  closed_by: closedBy, // Ex: "Ayrton Vargas Witcel Fidelis", null
+  labels // Ex: ["Technical Debt"]
+}) => ({
+  id,
+  projectId,
+  title,
+  description,
+  state,
+  createdAt: parseISODate(createdAt),
+  updatedAt: parseISODate(updatedAt),
+  closedAt: parseISODate(closedAt),
+  closedBy: closedBy ? parseUser(closedBy) : null,
+  labels
+})
+
+export { parser }

--- a/repositories/index.js
+++ b/repositories/index.js
@@ -1,9 +1,11 @@
 import { createUserRepository } from './user'
 import { createMRRepository } from './merge-request'
+import { createIssueRepository } from './issue'
 
 const createRepositories = ({ clients }) => ({
   user: createUserRepository({ clients }),
-  mergeRequest: createMRRepository({ clients })
+  mergeRequest: createMRRepository({ clients }),
+  issue: createIssueRepository({ clients })
 })
 
 export { createRepositories }

--- a/repositories/issue.js
+++ b/repositories/issue.js
@@ -1,0 +1,26 @@
+import { parseIssue } from '../parsers/gitlab-api'
+
+const getIssuesByGroupIdAndLabels = ({ clients }) => async (groupId, labels = []) => {
+  let issues = []
+  let page = 1
+  const perPage = 100
+  const labelsParam = labels.length ? `labels=${labels.join(',')}` : ''
+
+  while (true) {
+    const response =
+      // eslint-disable-next-line no-await-in-loop
+      await clients.gitlabApi(`/groups/${groupId}/issues?scope=all&page=${page}&per_page=${perPage}&${labelsParam}`)
+        .then((body) => body.json())
+        .then((issues) => issues.map(parseIssue))
+
+    issues = issues.concat(response)
+    if (response.length < perPage) break
+    page += page
+  }
+
+  return issues
+}
+
+export const createIssueRepository = ({ clients }) => ({
+  getIssuesByGroupIdAndLabels: getIssuesByGroupIdAndLabels({ clients })
+})

--- a/views/issues-board.ejs
+++ b/views/issues-board.ejs
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Issues Over Time</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 20px;
+      overflow: auto; /* Habilita a rolagem se o conteúdo for maior que a tela */
+    }
+    #chart-container {
+      width: 1280px; /* Largura fixa */
+      height: 720px; /* Altura fixa */
+      margin: auto;
+      display: block;
+      overflow: auto;
+    }
+    canvas {
+      width: 100% !important;  /* Para garantir que o gráfico ocupe toda a largura do container */
+      height: 100% !important; /* Para garantir que o gráfico ocupe toda a altura do container */
+    }
+  </style>
+</head>
+<body>
+  <h1>Issues Over Time</h1>
+  <h2>labels: <%= labels %></h2>
+  <div id="chart-container">
+    <canvas id="issuesChart"></canvas>
+  </div>
+
+  <script>
+        const data =  <%- JSON.stringify(issuesCountByWeek) %>
+
+        console.log(data)
+
+        const { notClosedIssuesByWeek, openedIssuesByWeek, closedIssuesByWeek } = data
+
+        // Prepara os dados para o gráfico
+        const labels = notClosedIssuesByWeek.map((entry) => entry.week);
+
+        const notClosedIssuesByWeekCounts = notClosedIssuesByWeek.map((entry) => entry.count);
+        const openedIssuesByWeekCounts = openedIssuesByWeek.map((entry) => entry.count);
+        const closedIssuesByWeekCounts = closedIssuesByWeek.map((entry) => entry.count);
+
+        // Configura o gráfico
+        const ctx = document.getElementById('issuesChart').getContext('2d');
+        new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: labels,
+            datasets: [{
+              label: 'Open Issues',
+              data: notClosedIssuesByWeekCounts,
+              borderColor: 'rgba(205, 202, 25, 1)',
+              backgroundColor: 'rgba(255, 255, 255, 0)',
+              borderWidth: 2,
+              fill: true,
+            }, {
+              label: 'Opened Issues By Week',
+              data: openedIssuesByWeekCounts,
+              borderColor: 'rgba(192, 0, 57, 1)',
+              backgroundColor: 'rgba(255, 255, 255, 0)',
+              borderWidth: 2,
+              fill: true,
+            }, {
+              label: 'Closed Issues By Week',
+              data: closedIssuesByWeekCounts,
+              borderColor: 'rgba(64, 155, 15, 1)',
+              backgroundColor: 'rgba(255, 255, 255, 0)',
+              borderWidth: 2,
+              fill: true,
+            }],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false, // Permite que o gráfico tenha o tamanho fixo especificado
+            scales: {
+              x: {
+                type: 'category',
+                title: {
+                  display: true,
+                  text: 'Week',
+                },
+                ticks: {
+                  autoSkip: true,
+                  maxTicksLimit: 20, // Limita o número de ticks no eixo X para evitar sobrecarga
+                },
+                reverse: false,
+              },
+              y: {
+                beginAtZero: true,
+                title: {
+                  display: true,
+                  text: 'Issues Count',
+                },
+              },
+            },
+          },
+        });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a route (/issues/:groupId) that renders a page with a dashboard that shows how many issues are opened and closed over the last 4 months in a group namespace (based on the `:groupId` param)